### PR TITLE
Fixing Xpra Issues

### DIFF
--- a/virtue/run.py
+++ b/virtue/run.py
@@ -111,6 +111,7 @@ def start_container(conf, docker_client, args):
                 'environment': environment,
                 'security_opt': security_opt,
                 'name': container_name,
+                'shm_size' : '2G',
             }
 
             if args.restart:

--- a/virtue/virtue-base/30_picture.conf
+++ b/virtue/virtue-base/30_picture.conf
@@ -1,0 +1,93 @@
+################################################################################
+# Picture Encoding
+
+# Encodings allowed:
+# (not all encodings may be available in your environment):
+#encodings = h264, vp8, png, png/P, png/L, webp, rgb, jpeg, h265, vp9
+#encodings = all
+encodings = rgb
+##encodings = all
+
+# Default encoding
+# (not all encodings may be available in your environment):
+#encoding = h264
+#encoding = vp8
+#encoding = png
+#encoding = jpeg
+encoding = rgb
+#encoding = webp
+##encoding = auto
+
+# Used by the server to encode video:
+# video-encoders = x264, vpx, nvenc
+# video-encoders = none
+# video-encoders = all
+video-encoders = all
+
+# Used by both the client and server for colourspace conversion:
+# csc-modules = swscale, libyuv
+# csc-modules = none
+# csc-modules = all
+csc-modules = all
+
+# Used by the client for decoding:
+# video-decoders = avcodec2, vpx
+# video-decoders = none
+# video-decoders = all
+video-decoders = all
+
+# Automatic video downscaling:
+# video-scaling = 0		#same as off
+# video-scaling = off
+# video-scaling = auto		#use quality and speed settings
+# video-scaling = on		#same as auto
+# video-scaling = 10		#mild automatic downscaling
+# video-scaling = 100		#very aggressive downscaling
+video-scaling = auto
+
+# Use fixed quality
+# (value is a percentage or "auto"):
+#quality = 80
+quality = auto
+
+# For auto quality only:
+#min-quality = 50
+min-quality = 30
+
+# Use fixed speed
+# (value is a percentage or "auto"):
+#speed = 90
+speed = auto
+
+# For auto speed only:
+#min-speed = 0
+min-speed = 30
+
+# Idle delay in seconds before doing an automatic lossless refresh:
+auto-refresh-delay = 0.15
+
+# Use a fixed DPI:
+#dpi = 96
+#automatic (which is the default):
+#dpi = 0
+
+# Bit depth of the virtual display or client display:
+# (this will be added to the xvfb command line above as "-depth VALUE")
+# for automatic mode, use the value 0:
+#pixel-depth = 0
+#pixel-depth = 16
+#pixel-depth = 24
+#pixel-depth = 30
+pixel-depth = 0
+
+# Video encoders loaded by the server
+# (all of them unless specified)
+# examples:
+#video-encoders=x264,vpx,nvenc
+#video-encoders=x264
+
+# Colourspace conversion modules loaded by the server
+# (all of them unless specified)
+# examples:
+#csc-modules=swscale,cython,opencl
+#csc-modules=swscale

--- a/virtue/virtue-base/Dockerfile.virtuebase
+++ b/virtue/virtue-base/Dockerfile.virtuebase
@@ -1,7 +1,6 @@
 ARG REPO=703915126451.dkr.ecr.us-east-2.amazonaws.com/starlab-virtue
 # REPO arg defined above to avoid warnings during building, but is unused because this is the base
 FROM ubuntu:16.04
-MAINTAINER Kyle Stapp <kyle.stapp@starlab.io>
 ENV DEBIAN_FRONTEND=noninteractive
 ENV USER root
 USER root
@@ -10,38 +9,38 @@ USER root
 RUN sed -e 's:deb h:deb [arch=amd64] h:' -e 's:deb-src h:deb-src [arch=amd64] h:' -i /etc/apt/sources.list && \
     find /etc/apt/sources.list.d/ -type f -exec sed -e 's:deb h:deb [arch=amd64] h:' -i {} \;
 
-# General Image Update
-RUN	apt-get -qy update && \
-	apt-get -qy install software-properties-common && \
-	add-apt-repository universe && \
-	apt-get autoremove -y && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
-
+# Install SSH Server and Curl
 RUN apt-get update && \
     apt-get -qy install openssh-server curl && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
-# Install Xpra/WinSwitch Repo
-RUN curl https://winswitch.org/gpg.asc | apt-key add - && \
-	echo "deb http://winswitch.org/ xenial main" > /etc/apt/sources.list.d/winswitch.list
-
 # Install Deps for xpra
 RUN apt-get update && \
     apt-get -qy install liblz4-tool python-gtkglext1 dbus dbus-x11 python-pip && \
+        python3-cryptography python3-kerberos python3-gssapi python3-gst-1.0 && \
+        python3-cups python3-paramiko python3-xdg && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 RUN pip install --upgrade pip
 RUN pip install numpy opencv-python websockify netifaces python-uinput
 
+# Install Beta Xpra/WinSwitch Repo
+RUN curl https://winswitch.org/gpg.asc | apt-key add -
+RUN echo "deb http://winswitch.org/beta/ xenial main" > /etc/apt/sources.list.d/winswitch.list;
+RUN echo "deb http://winswitch.org/ xenial main" >> /etc/apt/sources.list.d/winswitch.list;
+RUN apt-get install -y software-properties-common >& /dev/null;
+RUN add-apt-repository universe >& /dev/null;
+RUN apt-get update;
+RUN apt-get install xpra;
+
 # Install Xpra
 # Debug Tools
 # DebugExtras
 RUN apt-get update && \
-    apt-get -qy install xpra vim xvfb strace && \
+    apt-get -qy install vim xvfb strace && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
@@ -63,6 +62,7 @@ RUN ssh-keygen -t dsa -f ~/.ssh/ssh_host_dsa_key && \
 #Configure ssh to allow key based auth and grab key from env
 COPY sshd_config /home/virtue/
 COPY *.sh /home/virtue/
+COPY *.conf /etc/xpra/conf.d/
 
 #TBD Restrict SSH to only run the one xpra command
 

--- a/virtue/virtue-base/kickoff.sh
+++ b/virtue/virtue-base/kickoff.sh
@@ -3,5 +3,5 @@
 export XDG_RUNTIME_DIR=~/.xpra
 ~/set-authorized-keys.sh
 mkdir ~/.xpra
-xpra start --bind-tcp=0.0.0.0:2023 --html=on --start-child="$APP_TO_RUN"
+xpra start --bind-ws=0.0.0.0:2023 --start-child="$APP_TO_RUN" --log-file=/home/virtue/xpra.log --exit-with-children
 /usr/sbin/sshd -D -f ~/sshd_config


### PR DESCRIPTION
The dockerfile now downloads a beta version of Xpra that's much less laggy.
It also downloads some extra dependencies that were missing before.
I also added a config file for Xpra that deals with encoding values.
I edited the docker arguments so it runs with --shm-size=2G, so firefox has enough shared memory.
Finally, I edited the Xpra start command so it was less error prone.