### PR TITLE
Per-role Network Configuration

### DIFF
--- a/virtue/app-containers/Dockerfile.TEMPLATE
+++ b/virtue/app-containers/Dockerfile.TEMPLATE
@@ -13,5 +13,4 @@ RUN apt-get update && \
 
 ENV APP_TO_RUN <COMMAND_TO_RUN>
 EXPOSE <PORT_YOU_SPECIFIED>
-WORKDIR /home/virtue
-USER virtue
+

--- a/virtue/app-containers/Dockerfile.virtue-chrome
+++ b/virtue/app-containers/Dockerfile.virtue-chrome
@@ -17,5 +17,3 @@ RUN locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 ENV APP_TO_RUN "google-chrome-stable --no-sandbox"
-WORKDIR /home/virtue
-USER virtue

--- a/virtue/app-containers/Dockerfile.virtue-firefox
+++ b/virtue/app-containers/Dockerfile.virtue-firefox
@@ -13,5 +13,3 @@ RUN apt-get update && \
 
 ENV APP_TO_RUN firefox
 
-WORKDIR /home/virtue
-USER virtue

--- a/virtue/app-containers/Dockerfile.virtue-gedit
+++ b/virtue/app-containers/Dockerfile.virtue-gedit
@@ -13,5 +13,3 @@ RUN apt-get update && \
 
 ENV APP_TO_RUN gedit
 EXPOSE 6767
-WORKDIR /home/virtue
-USER virtue

--- a/virtue/app-containers/Dockerfile.virtue-powershell
+++ b/virtue/app-containers/Dockerfile.virtue-powershell
@@ -19,5 +19,3 @@ RUN	apt-get autoremove -y && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 ENV APP_TO_RUN "xterm pwsh"
-WORKDIR /home/virtue
-USER virtue

--- a/virtue/app-containers/Dockerfile.virtue-skype
+++ b/virtue/app-containers/Dockerfile.virtue-skype
@@ -25,5 +25,3 @@ RUN locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 ENV APP_TO_RUN skypeforlinux
-WORKDIR /home/virtue
-USER virtue

--- a/virtue/app-containers/Dockerfile.virtue-terminal
+++ b/virtue/app-containers/Dockerfile.virtue-terminal
@@ -15,5 +15,4 @@ RUN locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 ENV APP_TO_RUN "xterm -e /bin/bash"
-WORKDIR /home/virtue
-USER virtue
+

--- a/virtue/app-containers/Dockerfile.virtue-thunderbird
+++ b/virtue/app-containers/Dockerfile.virtue-thunderbird
@@ -15,5 +15,4 @@ RUN locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
 ENV APP_TO_RUN thunderbird
-WORKDIR /home/virtue
-USER virtue
+

--- a/virtue/run.py
+++ b/virtue/run.py
@@ -151,11 +151,9 @@ def start_container(conf, docker_client, args):
             
             # Copy network rules into the docker container
             print("Copying network rules...", end='', flush=True)
-            tar = tarfile.open('networkRules.tar',mode='w')
-            try:
+            with tarfile.open('networkRules.tar',mode='w') as tar:
                 tar.add('/etc/networkRules',arcname='networkRules')
-            finally:
-                tar.close()
+
             data = open('networkRules.tar','rb').read()
             container_obj.put_archive('/etc/',data)
             os.remove('./networkRules.tar')

--- a/virtue/run.py
+++ b/virtue/run.py
@@ -111,6 +111,7 @@ def start_container(conf, docker_client, args):
                 'environment': environment,
                 'security_opt': security_opt,
                 'name': container_name,
+                'cap_add': 'NET_ADMIN',
             }
 
             if args.restart:

--- a/virtue/run.py
+++ b/virtue/run.py
@@ -3,7 +3,7 @@
 # Author: Stanislav Ponomarev <stanislav.ponomarev@raytheon.com>
 # Copyright 2018 Raytheon BBN Technologies Corp.
 
-import sys, docker, subprocess, argparse, os
+import sys, docker, subprocess, argparse, os, tarfile
 from shutil import copyfile
 from ContainerConfig import ContainerConfig
 
@@ -146,6 +146,18 @@ def start_container(conf, docker_client, args):
         try:
             print("Starting service %s ..." % (container), end='', flush=True)
             container_obj.start()
+            print("[OK]")
+            
+            # Copy network rules into the docker container
+            print("Copying network rules...", end='', flush=True)
+            tar = tarfile.open('networkRules.tar',mode='w')
+            try:
+                tar.add('/etc/networkRules',arcname='networkRules')
+            finally:
+                tar.close()
+            data = open('networkRules.tar','rb').read()
+            container_obj.put_archive('/etc/',data)
+            os.remove('./networkRules.tar')
             print("[OK]")
         except docker.errors.APIError as e:
             print(e)

--- a/virtue/virtue-base/Dockerfile.virtuebase
+++ b/virtue/virtue-base/Dockerfile.virtuebase
@@ -46,6 +46,13 @@ RUN apt-get update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
 
+# Install iptables
+RUN apt-get update && \
+    apt-get -qy install iptables && \
+        apt-get autoremove -y && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
+
 #Create virtue user for sshd,xpra, and target app
 RUN useradd -ms /usr/sbin/nologin virtue
 USER virtue
@@ -66,5 +73,10 @@ COPY *.sh /home/virtue/
 
 #TBD Restrict SSH to only run the one xpra command
 
+
+USER root
+RUN chmod +x /home/virtue/kickoff_root.sh
+RUN chmod 777 /home/virtue/kickoff.sh
+
 #Auto start command
-CMD /home/virtue/kickoff.sh
+ENTRYPOINT ["/home/virtue/root_kickoff.sh"]

--- a/virtue/virtue-base/Dockerfile.virtuebase
+++ b/virtue/virtue-base/Dockerfile.virtuebase
@@ -79,4 +79,4 @@ RUN chmod +x /home/virtue/kickoff_root.sh
 RUN chmod 777 /home/virtue/kickoff.sh
 
 #Auto start command
-ENTRYPOINT ["/home/virtue/root_kickoff.sh"]
+ENTRYPOINT ["/home/virtue/kickoff_root.sh"]

--- a/virtue/virtue-base/kickoff_root.sh
+++ b/virtue/virtue-base/kickoff_root.sh
@@ -5,9 +5,9 @@
 # adding iptable rules.
 
 
-# Loop through the iptable.rules file and add them to the
+# Loop through the networkRules file and add them to the
 # iptable rule chains
-cat /etc/networkRules | while read line; do
+cat /home/virtue/networkRules | while read line; do
 	iptables $line
 done
 

--- a/virtue/virtue-base/kickoff_root.sh
+++ b/virtue/virtue-base/kickoff_root.sh
@@ -7,7 +7,7 @@
 
 # Loop through the networkRules file and add them to the
 # iptable rule chains
-cat /home/virtue/networkRules | while read line; do
+cat /etc/networkRules | while read line; do
 	iptables $line
 done
 

--- a/virtue/virtue-base/kickoff_root.sh
+++ b/virtue/virtue-base/kickoff_root.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script is ran by the root user; add any necessary
+# root commands that must be ran during startup such as
+# adding iptable rules.
+
+
+# Loop through the iptable.rules file and add them to the
+# iptable rule chains
+cat /root/iptables.rules | while read line; do
+	iptables $line
+done
+
+
+# Since the virtue user has a `nologin` shell, we cannot simply
+# `su` to virtue. Instead we execute the script on behalf of the
+# virtue user.
+su -s /bin/sh -c '/home/virtue/kickoff.sh' virtue

--- a/virtue/virtue-base/kickoff_root.sh
+++ b/virtue/virtue-base/kickoff_root.sh
@@ -17,4 +17,4 @@ done
 # Since the virtue user has a `nologin` shell, we cannot simply
 # `su` to virtue. Instead we execute the script on behalf of the
 # virtue user.
-su -s /bin/sh -c '/home/virtue/kickoff.sh' virtue
+runuser -u virtue -- /home/virtue/kickoff.sh

--- a/virtue/virtue-base/kickoff_root.sh
+++ b/virtue/virtue-base/kickoff_root.sh
@@ -4,6 +4,8 @@
 # root commands that must be ran during startup such as
 # adding iptable rules.
 
+# Allow enough time for the network rules to be copied over
+sleep 10
 
 # Loop through the networkRules file and add them to the
 # iptable rule chains

--- a/virtue/virtue-base/kickoff_root.sh
+++ b/virtue/virtue-base/kickoff_root.sh
@@ -7,7 +7,7 @@
 
 # Loop through the iptable.rules file and add them to the
 # iptable rule chains
-cat /root/iptables.rules | while read line; do
+cat /etc/networkRules | while read line; do
 	iptables $line
 done
 


### PR DESCRIPTION
Note: **this pull request should be pulled with the changes in the zratliff branch of the galahad repo**

These changes enable the use of per-role network configurations. The main changes to note is how **kickoff_root.sh** and **kickoff.sh** are used. In order to add iptable rules to a docker container, a privileged user must add the rules _after_ the container is already running. For this, we make the entrypoint execute the **kickoff_root.sh** script as the root user so that the network rules can be added.

After the iptable rules are added, we want to switch to the virtue user and execute **kickoff.sh** to start xpra and the given application (e.g. gedit). Since the virtue user has a _nologin_ shell, we must use the command:

`runuser -u virtue -- /home/virtue/kickoff.sh`

This command executes the **kickoff.sh** script on behalf of the virtue user, even though we are logged in as root. One caveat to this approach is that the **kickoff_root.sh** process will stay alive during the containers lifetime. 


NOTE: We will have to rebuild the docker containers on ECR after merging this PR.