### PR TITLE
Apparmor config files are only copied if restart option is set

### DIFF
--- a/virtue/run.py
+++ b/virtue/run.py
@@ -62,8 +62,7 @@ def start_container(conf, docker_client, args):
                         wfilecmd = list(cmd)
                         wfilecmd.append(file_entry)
                         subprocess.check_call(wfilecmd)
-                        if args.restart:
-                            copyfile(file_entry, os.path.join('/etc/apparmor.d/', os.path.basename(file_entry)))
+                        copyfile(file_entry, os.path.join('/etc/apparmor.d/', os.path.basename(file_entry)))
                 else:
                     # The following `with` block opens apparmor file and looks for profile_name inside the file
                     # But for the cases of multiple apparmor files this logic is way more complicated. 


### PR DESCRIPTION
- Removed check for restart option and copy the files regardless.
Without the restart option and these apparmor files the following
error is encountered trying to start up the containers:
Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused "apparmor failed to apply profile: write /proc/self/attr/exec: no such file or directory"": unknown
Error: failed to start containers: c471a3aa0dae