### PR TITLE
Apparmor config files are only copied if restart option is set

### DIFF
--- a/virtue/run.py
+++ b/virtue/run.py
@@ -79,8 +79,7 @@ def start_container(conf, docker_client, args):
                     wfilecmd = list(cmd)
                     wfilecmd.append(apparmor_file)
                     subprocess.check_call(wfilecmd)
-                    if args.restart:
-                        copyfile(apparmor_file, os.path.join('/etc/apparmor.d/', os.path.basename(apparmor_file)))
+                    copyfile(apparmor_file, os.path.join('/etc/apparmor.d/', os.path.basename(apparmor_file)))
                     
                 print("NOTE: Apparmor files are re-read only on container creation. If you change the file content, please remove the container and this this script again")
                 print("NOTE: Applying apparmor profile %s" % profile_name)


### PR DESCRIPTION
    - Missed additional check in else statement
    - Removed check for restart option and copy the files regardless.
    Without the restart option and these f apparmor files the following
    error is encountered trying to start up the containers:
    Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "process_linux.go:402: container init caused "apparmor failed to apply profile: write /proc/self/attr/exec: no such file or directory"": unknown
    Error: failed to start containers: c471a3aa0dae