### PR TITLE
fix file share resource mapping

### DIFF
--- a/virtue/VirtueDockerConf.yaml
+++ b/virtue/VirtueDockerConf.yaml
@@ -20,20 +20,34 @@ containers:
     gedit:
         image_tag: virtue-gedit
         ssh_port: 6767
+        args:
+            volumes:
+            - /home/virtue/gedit:/home/virtue/share
     firefox:
         image_tag: virtue-firefox
         ssh_port: 6768
         args:
             shm_size: 1g
+            volumes:
+            - /home/virtue/firefox:/home/virtue/share
     terminal:
         image_tag: virtue-terminal
         ssh_port: 6766
+        args:
+            volumes:
+            - /home/virtue/terminal:/home/virtue/share
     thunderbird:
         image_tag: virtue-thunderbird
         ssh_port: 6765
+        args:
+            volumes:
+            - /home/virtue/thunderbird:/home/virtue/share
     chrome:
         image_tag: virtue-chrome
         ssh_port: 6764
+        args:
+            volumes:
+            - /home/virtue/thunderbird:/home/virtue/share
     office-prep:
         image_tag: virtue-office-prep
         ssh_port: 6769
@@ -41,44 +55,55 @@ containers:
         seccomp: None
         args:
             volumes:
-             # Used to bring syslog messages from the container to the host's syslog-ng
-             - /dev/log:/dev/log
+            # Used to bring syslog messages from the container to the host's syslog-ng
+            - /dev/log:/dev/log
+            - /home/virtue/office-prep:/home/virtue/share
     powershell:
         image_tag: virtue-powershell
         ssh_port: 6761
         apparmor: None # This is an install container. Should be used only to install a given application
         seccomp: None
+        args:
+            volumes:
+            - /home/virtue/powershell:/home/virtue/share
     wincmd:
         image_tag: virtue-wincmd
         ssh_port: 6762
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
             volumes:
-             - /dev/log:/dev/log
+            - /dev/log:/dev/log
+            - /home/virtue/wincmd:/home/virtue/share
     skype:
         image_tag: virtue-skype
         ssh_port: 6763
+        args:
+            volumes:
+            - /home/virtue/skype:/home/virtue/share
     office-word:
         image_tag: virtue-office-word
         ssh_port: 6769
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
             volumes:
-             - /dev/log:/dev/log
+            - /dev/log:/dev/log
+            - /home/virtue/office-word:/home/virtue/share
     office-outlook:
         image_tag: virtue-office-outlook
         ssh_port: 6771
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
             volumes:
-             - /dev/log:/dev/log
+            - /dev/log:/dev/log
+            - /home/virtue/office-outlook:/home/virtue/share
     putty:
         image_tag: virtue-putty
         ssh_port: 6770
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
             volumes:
-             - /dev/log:/dev/log
+            - /dev/log:/dev/log
+            - /home/virtue/putty:/home/virtue/share
 
 # Sample Image Entry:
 # images:


### PR DESCRIPTION
This adds a `/home/virtue/share` in the docker container mount from the associated `/home/virtue/<appId>` directory in the virtue. This WILL NOT overwrite any existing directories and only applies to a fileshare resource.