### PR TITLE
Removed line which would rewrite the container's ~/.ssh/authorized_keys file

### DIFF
--- a/virtue/virtue-base/kickoff.sh
+++ b/virtue/virtue-base/kickoff.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 export XDG_RUNTIME_DIR=~/.xpra
-~/set-authorized-keys.sh
 mkdir ~/.xpra
 xpra start --bind-ws=0.0.0.0:2023 --start-child="$APP_TO_RUN" --log-file=/home/virtue/xpra.log --exit-with-children
 /usr/sbin/sshd -D -f ~/sshd_config


### PR DESCRIPTION
Excalibur now does that job with user-specific keys, so that users cannot access virtues they are not authorized for. `set-authorized-keys.sh` would only include the default virtue key, not the user's key.

Excalibur reference: https://github.com/starlab-io/galahad/blob/master/excalibur/website/apiendpoint.py#L441

This is required to resolve https://github.com/starlab-io/galahad/issues/412

I manually tested that this change, with those I made in the galahad repo, allow Canvas to connect with Xpra with the user's key.