### PR TITLE
Fixed container root user being unable to use ptrace and /proc/*/cwd

### DIFF
--- a/virtue/VirtueDockerConf.yaml
+++ b/virtue/VirtueDockerConf.yaml
@@ -21,12 +21,14 @@ containers:
         image_tag: virtue-gedit
         ssh_port: 6767
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /home/virtue/gedit:/home/virtue/share
     firefox:
         image_tag: virtue-firefox
         ssh_port: 6768
         args:
+            cap_add: SYS_PTRACE
             shm_size: 1g
             volumes:
             - /home/virtue/firefox:/home/virtue/share
@@ -34,18 +36,21 @@ containers:
         image_tag: virtue-terminal
         ssh_port: 6766
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /home/virtue/terminal:/home/virtue/share
     thunderbird:
         image_tag: virtue-thunderbird
         ssh_port: 6765
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /home/virtue/thunderbird:/home/virtue/share
     chrome:
         image_tag: virtue-chrome
         ssh_port: 6764
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /home/virtue/thunderbird:/home/virtue/share
     office-prep:
@@ -54,6 +59,7 @@ containers:
         apparmor: None # This is an install container. Should be used only to install a given application
         seccomp: None
         args:
+            cap_add: SYS_PTRACE
             volumes:
             # Used to bring syslog messages from the container to the host's syslog-ng
             - /dev/log:/dev/log
@@ -64,6 +70,7 @@ containers:
         apparmor: None # This is an install container. Should be used only to install a given application
         seccomp: None
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /home/virtue/powershell:/home/virtue/share
     wincmd:
@@ -71,6 +78,7 @@ containers:
         ssh_port: 6762
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /dev/log:/dev/log
             - /home/virtue/wincmd:/home/virtue/share
@@ -78,6 +86,7 @@ containers:
         image_tag: virtue-skype
         ssh_port: 6763
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /home/virtue/skype:/home/virtue/share
     office-word:
@@ -85,6 +94,7 @@ containers:
         ssh_port: 6769
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /dev/log:/dev/log
             - /home/virtue/office-word:/home/virtue/share
@@ -93,6 +103,7 @@ containers:
         ssh_port: 6771
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /dev/log:/dev/log
             - /home/virtue/office-outlook:/home/virtue/share
@@ -102,6 +113,7 @@ containers:
         apparmor: None  # use the Docker default
         seccomp: None   # This actually means "run with Docker default seccomp policy"
         args:
+            cap_add: SYS_PTRACE
             volumes:
             - /dev/log:/dev/log
             - /home/virtue/putty:/home/virtue/share

--- a/virtue/app-containers/apparmor/apparmor.chrome.profile
+++ b/virtue/app-containers/apparmor/apparmor.chrome.profile
@@ -13,6 +13,8 @@ profile docker_chrome flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.crossover.profile
+++ b/virtue/app-containers/apparmor/apparmor.crossover.profile
@@ -13,6 +13,8 @@ profile docker-crossover flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.firefox.profile
+++ b/virtue/app-containers/apparmor/apparmor.firefox.profile
@@ -13,6 +13,8 @@ profile docker_firefox flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.gedit.profile
+++ b/virtue/app-containers/apparmor/apparmor.gedit.profile
@@ -13,6 +13,8 @@ profile docker_gedit flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.office-outlook.profile
+++ b/virtue/app-containers/apparmor/apparmor.office-outlook.profile
@@ -13,6 +13,8 @@ profile docker_office_outlook flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.office-word.profile
+++ b/virtue/app-containers/apparmor/apparmor.office-word.profile
@@ -13,6 +13,8 @@ profile docker_office_word flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.office.profile
+++ b/virtue/app-containers/apparmor/apparmor.office.profile
@@ -13,6 +13,8 @@ profile docker_office flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.powershell.profile
+++ b/virtue/app-containers/apparmor/apparmor.powershell.profile
@@ -13,6 +13,8 @@ profile docker_powershell flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.putty.profile
+++ b/virtue/app-containers/apparmor/apparmor.putty.profile
@@ -20,6 +20,8 @@ profile kickoff flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/nameservice>
   #include <abstractions/python>
 
+  ptrace trace peer=*,
+
   /bin/bash rmix,
   /home/virtue/kickoff.sh r,
   /home/virtue/set-authorized-keys.sh rmix,

--- a/virtue/app-containers/apparmor/apparmor.skype.profile
+++ b/virtue/app-containers/apparmor/apparmor.skype.profile
@@ -13,6 +13,8 @@ profile docker_skype flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.terminal.profile
+++ b/virtue/app-containers/apparmor/apparmor.terminal.profile
@@ -13,6 +13,8 @@ profile docker_terminal flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.thunderbird.profile
+++ b/virtue/app-containers/apparmor/apparmor.thunderbird.profile
@@ -13,6 +13,8 @@ profile docker_thunderbird flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,

--- a/virtue/app-containers/apparmor/apparmor.wincmd.profile
+++ b/virtue/app-containers/apparmor/apparmor.wincmd.profile
@@ -13,6 +13,8 @@ profile docker_wincmd flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  ptrace trace peer=*,
+
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,


### PR DESCRIPTION
Changed apparmor and docker configs to allow root to use ptrace and access /proc/*/cwd inside each container

Tested to make sure non-root users can't access root's /proc/*/cwd files