### PR TITLE
Changed the firefox container to use firefox version 65.0

### DIFF
--- a/virtue/app-containers/Dockerfile.virtue-firefox
+++ b/virtue/app-containers/Dockerfile.virtue-firefox
@@ -6,10 +6,12 @@ ENV USER root
 USER root
 
 RUN apt-get update && \
-    apt-get -qy install firefox && \
-	apt-get autoremove -y && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/*
+    apt-get -qy install wget dh-python distro-info-data file libasound2 libasound2-data libcanberra0 libdbusmenu-glib4 libdbusmenu-gtk3-4 libmagic1 libmpdec2 libogg0 libpython3-stdlib libpython3.5-minimal libpython3.5-stdlib libstartup-notification0 libtdb1 libvorbis0a libvorbisfile3 libxcb-util1 lsb-release mime-support python3 python3-minimal python3.5 python3.5-minimal sound-theme-freedesktop xul-ext-ubufox && \
+    wget https://sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_65.0-0ubuntu1_amd64.deb && \
+    apt-get -qy install ./firefox-mozilla-build_65.0-0ubuntu1_amd64.deb && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists* /tmp/* /var/tmp/* ./firefox-mozilla-build_65.0-0ubuntu1_amd64.deb
 
 ENV APP_TO_RUN firefox
 


### PR DESCRIPTION
The latest version (67.0) consistently freezes the virtue soon after launching. Version 65.0 is the version our existing containers use and work with. I have manually tested that Canvas can control firefox after this change.

I would have used apt's built-in "firefox=version_code", but it seems that old versions of firefox get removed from the repositories.